### PR TITLE
docs: include inseri core to the related-projects.md

### DIFF
--- a/docs/project/related-projects.md
+++ b/docs/project/related-projects.md
@@ -54,3 +54,4 @@
 - [SymPy Beta](https://github.com/eagleoflqj/sympy_beta) is a fork of SymPy
   Gamma. It's an in-browser answer engine with a Pyodide backend.
 - [react-py](https://github.com/elilambnz/react-py) is a library that allows for easy integration of Pyodide in React applications. It provides convenient hooks for running Python code.
+- [inseri core](https://wordpress.org/plugins/inseri-core/) is a WordPress plugin developed that introduces scientific and interactive Gutenberg blocks to facilitate open science. The [Python Code block](https://docs.inseri.swiss/blocks/python/) allows to run Python code in the browser.


### PR DESCRIPTION
### Description

[inseri core](https://wordpress.org/plugins/inseri-core/) has the [Python Code block](https://docs.inseri.swiss/blocks/python/) that is using Pyodide behind the scene.
